### PR TITLE
Fix hanging CLI when Storybook plugin is executed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -597,6 +597,15 @@
       "integrity": "sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "^24.0.18",
     "@types/jsdom": "^12.2.4",
     "@types/node": "^12.7.5",
+    "@types/node-fetch": "^2.5.4",
     "@types/url-join": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",

--- a/src/storybook/stories.d.ts
+++ b/src/storybook/stories.d.ts
@@ -7,4 +7,4 @@ export interface Story {
   filePath: string;
 }
 
-export function loadStoriesFromURL(url: string, { verbose }?: { verbose: boolean }): Promise<Story[]>;
+export function loadStoriesFromURL(url: string): Promise<Story[]>;

--- a/src/storybook/stories.js
+++ b/src/storybook/stories.js
@@ -9,7 +9,7 @@ import { addShimsToJSDOM } from './jsdom-shims';
 
 const separator = '=========================';
 
-export async function loadStoriesFromURL(url, { verbose = false } = {}) {
+export async function loadStoriesFromURL(url) {
   const warnings = [];
   const errors = [];
   const virtualConsole = new VirtualConsole();
@@ -23,10 +23,6 @@ export async function loadStoriesFromURL(url, { verbose = false } = {}) {
   virtualConsole.on('jsdomError', l => {
     errors.push(l);
   });
-
-  if (verbose) {
-    virtualConsole.sendTo(log);
-  }
 
   const resourceLoader = new ResourceLoader({
     userAgent: "Zeplin CLI"

--- a/src/storybook/stories.js
+++ b/src/storybook/stories.js
@@ -39,10 +39,13 @@ export async function loadStoriesFromURL(url) {
   });
 
   await new Promise((resolve, reject) => {
-    dom.window.addEventListener('DOMContentLoaded', () => resolve());
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       reject(new Error('ContentLoadEvent timed out'));
     }, 60000);
+    dom.window.addEventListener('DOMContentLoaded', () => {
+      clearTimeout(timeoutId);
+      resolve();
+    });
   });
 
   // If the app logged something to console.error, it's probably, but not definitely an issue.


### PR DESCRIPTION
Uncleared setTimeout was causing winston logger to wait until the timer finished (60 secs).