### PR TITLE
Enhance file name matching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export default class implements ConnectPlugin {
 
                 const componentFileName = path.basename(componentConfig.path, path.extname(componentConfig.path));
 
-                return componentConfig.path === filePath ||
+                return path.relative(".", componentConfig.path) === path.relative(".", filePath) ||
                     componentName === componentFileName ||
                     storyDisplayName === componentFileName;
             });

--- a/src/storybook/extract.js
+++ b/src/storybook/extract.js
@@ -1,13 +1,22 @@
 // Original file: https://github.com/chromaui/chromatic-cli/blob/6ed2142/bin/storybook/extract.js
 
-function specFromStory({ id, kind, name, parameters: { component, framework } = {} }, componentPathMap) {
+function specFromStory(
+  { id, kind, name, parameters: { component, framework, fileName } = {} },
+  componentPathMap = {}
+) {
+  let filePath = component ? componentPathMap[component.displayName] : "";
+
+  if (!filePath && typeof fileName === "string") {
+    filePath = fileName;
+  }
+
   return {
     storyId: id,
     name,
     kind,
     displayName: kind.split(/\||\/|\./).slice(-1)[0],
     componentName: component ? component.displayName : "",
-    filePath: component && componentPathMap ? componentPathMap[component.displayName] : ""
+    filePath
   };
 }
 


### PR DESCRIPTION
1- We fill in filePath using `story.parameters.fileName` if component info could not be found in  `STORYBOOK_REACT_CLASSES` (seems to be supported in Storybook 5+) for better chance of finding matching story.

2- `story.parameters.fileName` contains file paths starting with `./`. Regardless of using that value, I found out components were already could not match if the user also type in component `path`s starting with `./`. So we now use `path.relative` to normalize file paths coming from Storybook and CLI config file.

**Previous**
- Story with `filePath: "./src/component.js"` and component with `path: "src/component.js"` was not matching.
- Story with `filePath: "src/component.js"` and component with `path: "./src/component.js"` was not matching.

**Current**
- Story with `filePath: "./src/component.js"` matches component with `path: "src/component.js"`.
- Story with `filePath: "src/component.js"` matches component with `path: "./src/component.js"`.