### PR TITLE
Add ignoreSSLErrors conf parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ You can use `useDocsPage` parameter to generate DocsPage hyperlinks if you use [
 }
 ```
 
+### Ignore SSL certificate errros
+
+In case you would need to ignore SSL certificate errors:
+```jsonc
+{
+    ...
+    "plugins" : [{
+        "name": "@zeplin/cli-connect-storybook-plugin",
+        "config": {
+            "url": "https://storybook.example.com",
+            "ignoreSSLErrors": true
+        }
+    }],
+    ...
+}
+```
+
+
 ## About Connected Components
 
 [Connected Components](https://blog.zeplin.io/introducing-connected-components-components-in-design-and-code-in-harmony-aa894ed5bd95) in Zeplin lets you access components in your codebase directly on designs in Zeplin, with links to Storybook, GitHub and any other source of documentation based on your workflow. 🧩

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ interface StorybookPluginConfig {
     format?: "old" | "new";
     useDocsPage?: boolean;
     failFastOnErrors?: boolean;
+    ignoreSSLErrors?: boolean;
 }
 
 interface StorybookComponentConfig {
@@ -84,8 +85,9 @@ export default class implements ConnectPlugin {
             targetUrl,
             startScript,
             command,
+            useDocsPage,
             failFastOnErrors,
-            useDocsPage
+            ignoreSSLErrors
         } = this.config;
 
         this.sourceUrl = url.endsWith(IFRAME_PATH) ? url : urlJoin(url, IFRAME_PATH);
@@ -96,7 +98,7 @@ export default class implements ConnectPlugin {
             throw new Error(`Missing Storybook configuration. `);
         } else if (!startScript && !command) {
             await checkStorybook(this.sourceUrl, { errorMessage: "Make sure you've started it and it is accessible." });
-            this.stories = await loadStoriesFromURL(this.sourceUrl, { failFastOnErrors });
+            this.stories = await loadStoriesFromURL(this.sourceUrl, { ignoreSSLErrors, failFastOnErrors });
         } else {
             const sbProcess = await startApp({
                 args: ["--ci"],
@@ -112,7 +114,7 @@ export default class implements ConnectPlugin {
             });
 
             try {
-                this.stories = await loadStoriesFromURL(this.sourceUrl, { failFastOnErrors });
+                this.stories = await loadStoriesFromURL(this.sourceUrl, { ignoreSSLErrors, failFastOnErrors });
             } finally {
                 sbProcess?.kill();
             }

--- a/src/storybook/stories.d.ts
+++ b/src/storybook/stories.d.ts
@@ -11,4 +11,6 @@ export interface Story {
   };
 }
 
-export function loadStoriesFromURL(url: string, params: { failFastOnErrors?: boolean }): Promise<Story[]>;
+export function loadStoriesFromURL(
+  url: string, params: { ignoreSSLErrors?: boolean; failFastOnErrors?: boolean }
+): Promise<Story[]>;

--- a/src/storybook/stories.js
+++ b/src/storybook/stories.js
@@ -9,7 +9,7 @@ import { addShimsToJSDOM } from './jsdom-shims';
 
 const separator = '=========================';
 
-export async function loadStoriesFromURL(url, { failFastOnErrors = false }) {
+export async function loadStoriesFromURL(url, { ignoreSSLErrors = false, failFastOnErrors = false }) {
   const warnings = [];
   const errors = [];
   const virtualConsole = new VirtualConsole();
@@ -25,7 +25,8 @@ export async function loadStoriesFromURL(url, { failFastOnErrors = false }) {
   });
 
   const resourceLoader = new ResourceLoader({
-    userAgent: "Zeplin CLI"
+    userAgent: "Zeplin CLI",
+    strictSSL: !ignoreSSLErrors
   });
   const dom = await JSDOM.fromURL(url, {
     userAgent: "Zeplin CLI",


### PR DESCRIPTION
A new plugin configuration parameter is added to provide the users a way to ignore SSL errors while loading Storybook via jsdom.